### PR TITLE
setAdapter should unregister from current adapter

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -474,11 +474,11 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
      */
     public void setAdapter(SparkAdapter adapter) {
         if (this.adapter != null) {
-            adapter.unregisterDataSetObserver(dataSetObserver);
+            this.adapter.unregisterDataSetObserver(dataSetObserver);
         }
         this.adapter = adapter;
         if (this.adapter != null) {
-            adapter.registerDataSetObserver(dataSetObserver);
+            this.adapter.registerDataSetObserver(dataSetObserver);
         }
         populatePath();
     }


### PR DESCRIPTION
The current implementation unregisters from the new adapter, which
is incorrect and leads to the old adapter never being unregistered.