### PR TITLE
lower minSdkVersion to 14 (ICS) closes #13

### DIFF
--- a/spark-sample/build.gradle
+++ b/spark-sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.robinhood.spark.sample"
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 23
     }
 


### PR DESCRIPTION
Spark can be safely used down to Ice Cream Sandwich. It's also compatible with the Honeycomb APIs, but I only tested down to API level 14.