### PR TITLE
Adjust data bounds to account for lines.

### DIFF
--- a/spark-sample/src/main/java/com/robinhood/spark/sample/MainActivity.java
+++ b/spark-sample/src/main/java/com/robinhood/spark/sample/MainActivity.java
@@ -16,8 +16,8 @@
 
 package com.robinhood.spark.sample;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.TextView;
 

--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -596,6 +596,10 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
 
             // get data bounds from adapter
             RectF bounds = adapter.getDataBounds();
+
+            // if data is a line (which technically has no size), expand bounds to center the data
+            bounds.inset(bounds.width() == 0 ? -1 : 0, bounds.height() == 0 ? -1 : 0);
+
             final float minX = bounds.left;
             final float maxX = bounds.right;
             final float minY = bounds.top;

--- a/spark/src/test/java/com/robinhood/spark/ScaleHelperUnitTest.java
+++ b/spark/src/test/java/com/robinhood/spark/ScaleHelperUnitTest.java
@@ -153,7 +153,7 @@ public class ScaleHelperUnitTest {
         SparkView.ScaleHelper scaleHelper = new SparkView.ScaleHelper(testAdapter, contentRect, 0,
                 false);
 
-        // assert point 1 is left middle
+        // assert point 0 is left middle
         float x0 = scaleHelper.getX(testAdapter.getX(0));
         float y0 = scaleHelper.getY(testAdapter.getY(0));
         assertEquals(0f, x0);
@@ -165,7 +165,7 @@ public class ScaleHelperUnitTest {
         assertEquals(50f, x1);
         assertEquals(50f, y1);
 
-        // assert point 1 is right middle
+        // assert point 2 is right middle
         float x2 = scaleHelper.getX(testAdapter.getX(2));
         float y2 = scaleHelper.getY(testAdapter.getY(2));
         assertEquals(100f, x2);
@@ -179,7 +179,7 @@ public class ScaleHelperUnitTest {
         SparkView.ScaleHelper scaleHelper = new SparkView.ScaleHelper(testAdapter, contentRect, 0,
                 false);
 
-        // assert point 1 is middle bottom
+        // assert point 0 is middle bottom
         float x0 = scaleHelper.getX(testAdapter.getX(0));
         float y0 = scaleHelper.getY(testAdapter.getY(0));
         assertEquals(50f, x0);
@@ -191,7 +191,7 @@ public class ScaleHelperUnitTest {
         assertEquals(50f, x1);
         assertEquals(50f, y1);
 
-        // assert point 1 is middle top
+        // assert point 2 is middle top
         float x2 = scaleHelper.getX(testAdapter.getX(2));
         float y2 = scaleHelper.getY(testAdapter.getY(2));
         assertEquals(50f, x2);

--- a/spark/src/test/java/com/robinhood/spark/ScaleHelperUnitTest.java
+++ b/spark/src/test/java/com/robinhood/spark/ScaleHelperUnitTest.java
@@ -123,7 +123,7 @@ public class ScaleHelperUnitTest {
     @Test
     public void testNonWrappingDataBounds() {
         testAdapter.setYData(new float[] {0, 50, 100});
-        // set bounds to 'zoon in' on the first two points
+        // set bounds to 'zoom in' on the first two points
         testAdapter.setDataBounds(0, 0, 1, 50);
         SparkView.ScaleHelper scaleHelper = new SparkView.ScaleHelper(testAdapter, contentRect, 0,
                 false);
@@ -145,5 +145,56 @@ public class ScaleHelperUnitTest {
         float y2 = scaleHelper.getY(testAdapter.getY(2));
         assertEquals(200f, x2);
         assertEquals(-100f, y2);
+    }
+
+    @Test
+    public void testHorizontalLine() {
+        testAdapter.setYData(new float[] {25, 25, 25});
+        SparkView.ScaleHelper scaleHelper = new SparkView.ScaleHelper(testAdapter, contentRect, 0,
+                false);
+
+        // assert point 1 is left middle
+        float x0 = scaleHelper.getX(testAdapter.getX(0));
+        float y0 = scaleHelper.getY(testAdapter.getY(0));
+        assertEquals(0f, x0);
+        assertEquals(50f, y0);
+
+        // assert point 1 is middle middle
+        float x1 = scaleHelper.getX(testAdapter.getX(1));
+        float y1 = scaleHelper.getY(testAdapter.getY(1));
+        assertEquals(50f, x1);
+        assertEquals(50f, y1);
+
+        // assert point 1 is right middle
+        float x2 = scaleHelper.getX(testAdapter.getX(2));
+        float y2 = scaleHelper.getY(testAdapter.getY(2));
+        assertEquals(100f, x2);
+        assertEquals(50f, y2);
+    }
+
+    @Test
+    public void testVerticalLine() {
+        testAdapter.setYData(new float[] {0, 50, 100});
+        testAdapter.setXData(new float[] {25, 25, 25});
+        SparkView.ScaleHelper scaleHelper = new SparkView.ScaleHelper(testAdapter, contentRect, 0,
+                false);
+
+        // assert point 1 is middle bottom
+        float x0 = scaleHelper.getX(testAdapter.getX(0));
+        float y0 = scaleHelper.getY(testAdapter.getY(0));
+        assertEquals(50f, x0);
+        assertEquals(100f, y0);
+
+        // assert point 1 is middle middle
+        float x1 = scaleHelper.getX(testAdapter.getX(1));
+        float y1 = scaleHelper.getY(testAdapter.getY(1));
+        assertEquals(50f, x1);
+        assertEquals(50f, y1);
+
+        // assert point 1 is middle top
+        float x2 = scaleHelper.getX(testAdapter.getX(2));
+        float y2 = scaleHelper.getY(testAdapter.getY(2));
+        assertEquals(50f, x2);
+        assertEquals(0f, y2);
     }
 }

--- a/spark/src/test/java/com/robinhood/spark/TestAdapter.java
+++ b/spark/src/test/java/com/robinhood/spark/TestAdapter.java
@@ -2,7 +2,13 @@ package com.robinhood.spark;
 
 import android.graphics.RectF;
 
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 public class TestAdapter extends SparkAdapter {
@@ -56,13 +62,31 @@ public class TestAdapter extends SparkAdapter {
     }
 
     public static RectF createMockRectF(float left, float top, float right, float bottom) {
-        RectF rectF = mock(RectF.class);
+        final RectF rectF = mock(RectF.class);
         rectF.left = left;
         rectF.top = top;
         rectF.right = right;
         rectF.bottom = bottom;
         when(rectF.width()).thenReturn(right - left);
         when(rectF.height()).thenReturn(bottom - top);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                reset(rectF);
+                Object[] args = invocation.getArguments();
+                float dx = (float) args[0];
+                float dy = (float) args[1];
+                rectF.left += dx;
+                rectF.top += dy;
+                rectF.right -= dx;
+                rectF.bottom -= dy;
+                when(rectF.width()).thenReturn(rectF.right - rectF.left);
+                when(rectF.height()).thenReturn(rectF.bottom - rectF.top);
+                return null;
+            }
+        }).when(rectF).inset(anyFloat(), anyFloat());
+
         return rectF;
     }
 }

--- a/spark/src/test/java/com/robinhood/spark/TestAdapter.java
+++ b/spark/src/test/java/com/robinhood/spark/TestAdapter.java
@@ -67,8 +67,8 @@ public class TestAdapter extends SparkAdapter {
         rectF.top = top;
         rectF.right = right;
         rectF.bottom = bottom;
-        when(rectF.width()).thenReturn(right - left);
-        when(rectF.height()).thenReturn(bottom - top);
+        when(rectF.width()).thenReturn(rectF.right - rectF.left);
+        when(rectF.height()).thenReturn(rectF.bottom - rectF.top);
 
         doAnswer(new Answer<Void>() {
             @Override
@@ -81,8 +81,6 @@ public class TestAdapter extends SparkAdapter {
                 rectF.top += dy;
                 rectF.right -= dx;
                 rectF.bottom -= dy;
-                when(rectF.width()).thenReturn(rectF.right - rectF.left);
-                when(rectF.height()).thenReturn(rectF.bottom - rectF.top);
                 return null;
             }
         }).when(rectF).inset(anyFloat(), anyFloat());


### PR DESCRIPTION
Closes #18 

If data bounds are width or height 0, expand the data bounds by 1 to center the data.