### PR TITLE
Add fillType functionality. Closes #31

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -30,14 +30,18 @@ import android.graphics.RectF;
 import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.ColorInt;
+import android.support.annotation.IntDef;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewConfiguration;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A {@link SparkView} is a simplified line chart with no axes.
@@ -45,11 +49,46 @@ import java.util.List;
 public class SparkView extends View implements ScrubGestureDetector.ScrubListener {
     private static final String TAG = "Spark";
 
+    /**
+     * Holds the fill type constants to be used with {@linkplain #getFillType()} and
+     * {@linkplain #setFillType(int)}
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({
+            FillType.NONE,
+            FillType.UP,
+            FillType.DOWN,
+            FillType.TOWARD_ZERO,
+    })
+    public @interface FillType {
+        /**
+         * Fill type constant for having no fill on the graph
+         */
+        int NONE = 0;
+
+        /**
+         * Fill type constant for always filling the area above the sparkline.
+         */
+        int UP = 1;
+
+        /**
+         * Fill type constant for always filling the area below the sparkline
+         */
+        int DOWN = 2;
+
+        /**
+         * Fill type constant for filling toward zero. This will fill downward if your sparkline is
+         * positive, or upward if your sparkline is negative. If your sparkline intersects zero,
+         * each segment will still color toward zero.
+         */
+        int TOWARD_ZERO = 3;
+    }
+
     // styleable values
     @ColorInt private int lineColor;
     private float lineWidth;
     private float cornerRadius;
-    private boolean fill;
+    private int fillType;
     @ColorInt private int baseLineColor;
     private float baseLineWidth;
     @ColorInt private int scrubLineColor;
@@ -106,7 +145,15 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         lineColor = a.getColor(R.styleable.spark_SparkView_spark_lineColor, 0);
         lineWidth = a.getDimension(R.styleable.spark_SparkView_spark_lineWidth, 0);
         cornerRadius = a.getDimension(R.styleable.spark_SparkView_spark_cornerRadius, 0);
-        fill = a.getBoolean(R.styleable.spark_SparkView_spark_fill, false);
+
+        // for backwards compatibility, set filltype based on fill
+        boolean fill = a.getBoolean(R.styleable.spark_SparkView_spark_fill, false);
+        fillType = fill ? FillType.DOWN : FillType.NONE;
+        int tempType = a.getInt(R.styleable.spark_SparkView_spark_fillType, -1);
+        if (tempType != -1) {
+            fillType = tempType;
+            fill = isFillInternal();
+        }
         baseLineColor = a.getColor(R.styleable.spark_SparkView_spark_baseLineColor, 0);
         baseLineWidth = a.getDimension(R.styleable.spark_SparkView_spark_baseLineWidth, 0);
         scrubEnabled = a.getBoolean(R.styleable.spark_SparkView_spark_scrubEnabled, true);
@@ -164,7 +211,7 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
             return;
         }
 
-        scaleHelper = new ScaleHelper(adapter, contentRect, lineWidth, fill);
+        scaleHelper = new ScaleHelper(adapter, contentRect, lineWidth, isFillInternal());
 
         // xPoints is only used in scrubbing, skip if disabled
         if (scrubEnabled) {
@@ -193,14 +240,14 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         }
 
         // if we're filling the graph in, close the path's circuit
-        if (fill) {
-            float lastX = scaleHelper.getX(adapter.getCount() - 1);
-            float bottom = getHeight() - getPaddingBottom();
-            // line straight down to the bottom of the view
-            sparkPath.lineTo(lastX, bottom);
+        final Float fillEdge = getFillEdge();
+        if (fillEdge != null) {
+            final float lastX = scaleHelper.getX(adapter.getCount() - 1);
+            // line up or down to the fill edge
+            sparkPath.lineTo(lastX, fillEdge);
             // line straight left to far edge of the view
-            sparkPath.lineTo(getPaddingStart(), bottom);
-            // line straight up to meet the first point
+            sparkPath.lineTo(getPaddingStart(), fillEdge);
+            // closes line back on the first point
             sparkPath.close();
         }
 
@@ -216,6 +263,25 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         renderPath.addPath(sparkPath);
 
         invalidate();
+    }
+
+    private Float getFillEdge() {
+        switch (fillType) {
+            case FillType.NONE:
+                return null;
+            case FillType.UP:
+                return 0F - getPaddingTop();
+            case FillType.DOWN:
+                return (float) getHeight() - getPaddingBottom();
+            case FillType.TOWARD_ZERO:
+                float zero = scaleHelper.getY(0F);
+                float bottom = (float) getHeight() - getPaddingBottom();
+                return Math.min(zero, bottom);
+            default:
+                throw new IllegalStateException(
+                        String.format(Locale.US, "Unknown fill-type: %d", fillType)
+                );
+        }
     }
 
     /**
@@ -366,18 +432,62 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
 
     /**
      * Return whether or not this sparkline should fill the area underneath.
+     *
+     * @deprecated use {@link #getFillType()} instead
      */
     public boolean isFill() {
-        return fill;
+        switch (fillType) {
+            case FillType.NONE:
+                return false;
+            case FillType.UP:
+            case FillType.DOWN:
+            case FillType.TOWARD_ZERO:
+                return true;
+            default:
+                throw new IllegalStateException(
+                        String.format(Locale.US, "Unknown fill-type: %d", fillType)
+                );
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private boolean isFillInternal() {
+        return isFill();
+    }
+
+    @FillType
+    public int getFillType() {
+        return fillType;
     }
 
     /**
      * Set whether or not this sparkline should fill the area underneath.
+     *
+     * @deprecated use {@link #setFillType(int)} instead
      */
+    @Deprecated
     public void setFill(boolean fill) {
-        if (this.fill != fill) {
-            this.fill = fill;
-            sparkLinePaint.setStyle(fill ? Paint.Style.FILL : Paint.Style.STROKE);
+        setFillType(fill ? FillType.DOWN : FillType.NONE);
+    }
+
+    public void setFillType(@FillType int fillType) {
+        if (this.fillType != fillType) {
+            this.fillType = fillType;
+
+            switch (fillType) {
+                case FillType.NONE:
+                    sparkLinePaint.setStyle(Paint.Style.STROKE);
+                    break;
+                case FillType.UP:
+                case FillType.DOWN:
+                case FillType.TOWARD_ZERO:
+                    sparkLinePaint.setStyle(Paint.Style.FILL);
+                default:
+                    throw new IllegalStateException(
+                            String.format(Locale.US, "Unknown fill-type: %d", fillType)
+                    );
+            }
+
             populatePath();
         }
     }

--- a/spark/src/main/res/values/attrs.xml
+++ b/spark/src/main/res/values/attrs.xml
@@ -6,7 +6,15 @@
         <attr name="spark_lineColor" format="color|reference" />
         <attr name="spark_lineWidth" format="dimension|reference" />
         <attr name="spark_cornerRadius" format="dimension|reference" />
+        <!-- {@deprecated Use fillType instead.} -->
         <attr name="spark_fill" format="boolean|reference" />
+        <attr name="spark_fillType" format="enum" >
+            <!-- must match values in SparkView.FillType -->
+            <enum name="none" value="0"/>
+            <enum name="up" value="1"/>
+            <enum name="down" value="2"/>
+            <enum name="towardZero" value="3"/>
+        </attr>
 
         <attr name="spark_baseLineColor" format="color|reference" />
         <attr name="spark_baseLineWidth" format="dimension|reference" />

--- a/spark/src/main/res/values/attrs.xml
+++ b/spark/src/main/res/values/attrs.xml
@@ -8,12 +8,12 @@
         <attr name="spark_cornerRadius" format="dimension|reference" />
         <!-- {@deprecated Use fillType instead.} -->
         <attr name="spark_fill" format="boolean|reference" />
-        <attr name="spark_fillType" format="enum" >
+        <attr name="spark_fillType" format="enum">
             <!-- must match values in SparkView.FillType -->
-            <enum name="none" value="0"/>
-            <enum name="up" value="1"/>
-            <enum name="down" value="2"/>
-            <enum name="towardZero" value="3"/>
+            <enum name="none" value="0" />
+            <enum name="up" value="1" />
+            <enum name="down" value="2" />
+            <enum name="towardZero" value="3" />
         </attr>
 
         <attr name="spark_baseLineColor" format="color|reference" />


### PR DESCRIPTION
Closes #31

Adds fillType attribute and getter/setter.

I tested manually on the sample project, including with sparks that intersect 0. I initially tried to also add an `awayFromZero` fill type, but it is more complicated when the spark intersects 0. Since I doubt it's a useful fill type at all, I'll omit until somebody explicitly requests it.