### PR TITLE
Fix lint error, and fillType bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - platform-tools
     - tools
-    - android-23
+    - android-26
     - build-tools-23.0.3
     - extra-android-m2repository
 

--- a/spark-sample/build.gradle
+++ b/spark-sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.robinhood.spark.sample"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile project(path: ':spark')
 }

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
 
     resourcePrefix 'spark_'

--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -88,7 +88,7 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
     @ColorInt private int lineColor;
     private float lineWidth;
     private float cornerRadius;
-    private int fillType;
+    @FillType private int fillType = -1;
     @ColorInt private int baseLineColor;
     private float baseLineWidth;
     @ColorInt private int scrubLineColor;
@@ -478,6 +478,7 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
                 case FillType.DOWN:
                 case FillType.TOWARD_ZERO:
                     sparkLinePaint.setStyle(Paint.Style.FILL);
+                    break;
                 default:
                     throw new IllegalStateException(
                             String.format(Locale.US, "Unknown fill-type: %d", fillType)


### PR DESCRIPTION
Travis build was failing due to missing updates.

Couple bugs with previous fillType refactoring:
- setFillType(none) in the constructor no-opped due to this.fillType == fillType
- setFillType(anythingElse) crashed due to missing break statement