### PR TITLE
Remove redundant casts in sample app.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - extra-android-m2repository
 
 script:
-  ./gradlew clean check
+  ./gradlew clean check --stacktrace
 
 jdk:
   - oraclejdk8

--- a/spark-sample/src/main/java/com/robinhood/spark/sample/MainActivity.java
+++ b/spark-sample/src/main/java/com/robinhood/spark/sample/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        sparkView = (SparkView) findViewById(R.id.sparkview);
+        sparkView = findViewById(R.id.sparkview);
 
         adapter = new RandomizedAdapter();
         sparkView.setAdapter(adapter);
@@ -65,11 +65,11 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        scrubInfoTextView = (TextView) findViewById(R.id.scrub_info_textview);
+        scrubInfoTextView = findViewById(R.id.scrub_info_textview);
 
         // set select
-        Spinner animationSpinner = (Spinner) findViewById(R.id.animation_spinner);
-        animationSpinner.setAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, getResources().getStringArray(R.array.animations)));
+        Spinner animationSpinner = findViewById(R.id.animation_spinner);
+        animationSpinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, getResources().getStringArray(R.array.animations)));
         animationSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {


### PR DESCRIPTION
Starting with API 26, `findViewById()` uses inference for its return type so we no longer have to cast. 