### PR TITLE
Use Gradle 3.4 dependency configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Download
 Gradle:
 
 ```groovy
-compile 'com.robinhood.spark:spark:1.2.0'
+implementation 'com.robinhood.spark:spark:1.2.0'
 ```
 
 

--- a/spark-sample/build.gradle
+++ b/spark-sample/build.gradle
@@ -20,8 +20,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile project(path: ':spark')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation project(path: ':spark')
 }

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -13,10 +13,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.10.0'
-    compile 'com.android.support:support-annotations:26.1.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.13.0'
+    implementation 'com.android.support:support-annotations:26.1.0'
 }
 
 apply from: 'gradle-mvn-push.gradle'


### PR DESCRIPTION
Migrates project to new dependency configurations.

`compile` and `testCompile` are deprecated as of Gradle 3.4:

https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations