### PR TITLE
Rename stylable tag to SparkView.

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -142,26 +142,26 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
     }
 
     private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.spark_SparkView,
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SparkView,
                 defStyleAttr, defStyleRes);
-        lineColor = a.getColor(R.styleable.spark_SparkView_spark_lineColor, 0);
-        lineWidth = a.getDimension(R.styleable.spark_SparkView_spark_lineWidth, 0);
-        cornerRadius = a.getDimension(R.styleable.spark_SparkView_spark_cornerRadius, 0);
+        lineColor = a.getColor(R.styleable.SparkView_spark_lineColor, 0);
+        lineWidth = a.getDimension(R.styleable.SparkView_spark_lineWidth, 0);
+        cornerRadius = a.getDimension(R.styleable.SparkView_spark_cornerRadius, 0);
 
         // for backwards compatibility, set fill type based on spark_fill first, then overwrite if
         // new spark_fillType attribute is set
-        int legacyFill = a.getBoolean(R.styleable.spark_SparkView_spark_fill, false)
+        int legacyFill = a.getBoolean(R.styleable.SparkView_spark_fill, false)
                 ? FillType.DOWN
                 : FillType.NONE;
-        int fillType = a.getInt(R.styleable.spark_SparkView_spark_fillType, legacyFill);
+        int fillType = a.getInt(R.styleable.SparkView_spark_fillType, legacyFill);
         setFillType(fillType);
 
-        baseLineColor = a.getColor(R.styleable.spark_SparkView_spark_baseLineColor, 0);
-        baseLineWidth = a.getDimension(R.styleable.spark_SparkView_spark_baseLineWidth, 0);
-        scrubEnabled = a.getBoolean(R.styleable.spark_SparkView_spark_scrubEnabled, true);
-        scrubLineColor = a.getColor(R.styleable.spark_SparkView_spark_scrubLineColor, baseLineColor);
-        scrubLineWidth = a.getDimension(R.styleable.spark_SparkView_spark_scrubLineWidth, lineWidth);
-        boolean animateChanges = a.getBoolean(R.styleable.spark_SparkView_spark_animateChanges, false);
+        baseLineColor = a.getColor(R.styleable.SparkView_spark_baseLineColor, 0);
+        baseLineWidth = a.getDimension(R.styleable.SparkView_spark_baseLineWidth, 0);
+        scrubEnabled = a.getBoolean(R.styleable.SparkView_spark_scrubEnabled, true);
+        scrubLineColor = a.getColor(R.styleable.SparkView_spark_scrubLineColor, baseLineColor);
+        scrubLineWidth = a.getDimension(R.styleable.SparkView_spark_scrubLineWidth, lineWidth);
+        boolean animateChanges = a.getBoolean(R.styleable.SparkView_spark_animateChanges, false);
         a.recycle();
 
         sparkLinePaint.setColor(lineColor);

--- a/spark/src/main/res/values/attrs.xml
+++ b/spark/src/main/res/values/attrs.xml
@@ -2,7 +2,7 @@
 <resources>
     <attr name="spark_SparkViewStyle" format="reference" />
 
-    <declare-styleable name="spark_SparkView">
+    <declare-styleable name="SparkView">
         <attr name="spark_lineColor" format="color|reference" />
         <attr name="spark_lineWidth" format="dimension|reference" />
         <attr name="spark_cornerRadius" format="dimension|reference" />


### PR DESCRIPTION
Addresses #43.

Verified autocomplete worked in Spark's sample project.