### PR TITLE
Taking padding and line width into account when scrubbing.

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -346,7 +346,29 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         invalidate();
     }
 
+    /**
+     * Checks to see if the x coordinate of the scrub falls within the bounding rect minus
+     * padding and the width of the scrub line, then performs a draw.
+     */
     private void setScrubLine(float x) {
+        float scrubLineOffset = scrubLineWidth / 2;
+
+        float leftBound = getPaddingStart() + scrubLineOffset;
+        if (x < leftBound) {
+            drawScrubLine(leftBound);
+            return;
+        }
+
+        float rightBound = getWidth() - getPaddingEnd() - scrubLineOffset;
+        if (x > rightBound) {
+            drawScrubLine(rightBound);
+            return;
+        }
+
+        drawScrubLine(x);
+    }
+
+    private void drawScrubLine(float x) {
         scrubLinePath.reset();
         scrubLinePath.moveTo(x, getPaddingTop());
         scrubLinePath.lineTo(x, getHeight() - getPaddingBottom());

--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -346,33 +346,31 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         invalidate();
     }
 
-    /**
-     * Checks to see if the x coordinate of the scrub falls within the bounding rect minus
-     * padding and the width of the scrub line, then performs a draw.
-     */
     private void setScrubLine(float x) {
-        float scrubLineOffset = scrubLineWidth / 2;
-
-        float leftBound = getPaddingStart() + scrubLineOffset;
-        if (x < leftBound) {
-            drawScrubLine(leftBound);
-            return;
-        }
-
-        float rightBound = getWidth() - getPaddingEnd() - scrubLineOffset;
-        if (x > rightBound) {
-            drawScrubLine(rightBound);
-            return;
-        }
-
-        drawScrubLine(x);
-    }
-
-    private void drawScrubLine(float x) {
+        x = resolveBoundedScrubLine(x);
         scrubLinePath.reset();
         scrubLinePath.moveTo(x, getPaddingTop());
         scrubLinePath.lineTo(x, getHeight() - getPaddingBottom());
         invalidate();
+    }
+
+    /**
+     * Bounds the x coordinate of a scrub within the bounding rect minus padding and line width.
+     */
+    private float resolveBoundedScrubLine(float x) {
+        float scrubLineOffset = scrubLineWidth / 2;
+
+        float leftBound = getPaddingStart() + scrubLineOffset;
+        if (x < leftBound) {
+            return leftBound;
+        }
+
+        float rightBound = getWidth() - getPaddingEnd() - scrubLineOffset;
+        if (x > rightBound) {
+            return rightBound;
+        }
+
+        return x;
     }
 
     @Override


### PR DESCRIPTION
This change bounds the scrub line within the view's bounding rect minus padding and the width of the line. Previously you could scrub all the way off the graph.

Tested various scrub line widths and padding configurations. Ensured full scrub bar is always shown and always falls within the bounding rect. 