### PR TITLE
"Horizontal Clipping"

### DIFF
--- a/spark/src/main/java/com/robinhood/spark/SparkView.java
+++ b/spark/src/main/java/com/robinhood/spark/SparkView.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.CornerPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -111,6 +112,7 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
     // misc fields
     private ScaleHelper scaleHelper;
     private Paint sparkLinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Paint sparkLineUnderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint sparkFillPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint baseLinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint scrubLinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -118,6 +120,9 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
     private ScrubGestureDetector scrubGestureDetector;
     private Animator pathAnimator;
     private final RectF contentRect = new RectF();
+    private float clipAmount = 1f;
+    private RectF clippedRect = new RectF();
+    public boolean clipOnScrub;
 
     private List<Float> xPoints;
     private List<Float> yPoints;
@@ -172,8 +177,11 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         sparkLinePaint.setColor(lineColor);
         sparkLinePaint.setStrokeWidth(lineWidth);
         sparkLinePaint.setStrokeCap(Paint.Cap.ROUND);
+        sparkLineUnderPaint = new Paint(sparkLinePaint);
+        sparkLineUnderPaint.setColor(Color.GRAY);
         if (cornerRadius != 0) {
             sparkLinePaint.setPathEffect(new CornerPathEffect(cornerRadius));
+            sparkLineUnderPaint.setPathEffect(new CornerPathEffect(cornerRadius));
         }
 
         sparkFillPaint.set(sparkLinePaint);
@@ -389,8 +397,26 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
             canvas.drawPath(renderPath, sparkFillPaint);
         }
 
+        if(clipAmount < 1) {
+            canvas.drawPath(renderPath, sparkLineUnderPaint);
+            canvas.save();
+            canvas.clipRect(clippedRect);
+        }
         canvas.drawPath(renderPath, sparkLinePaint);
+        if(clipAmount < 1) {
+            canvas.restore();
+        }
         canvas.drawPath(scrubLinePath, scrubLinePaint);
+    }
+
+    /**
+     * Set horizontal clip amount, set to 1 to disable clipping
+     * @param amount [0..1]
+     */
+    public void setClipAmount(float amount) {
+        clipAmount = Math.max(0f, Math.min(1f, amount));
+        this.clippedRect.right = contentRect.right * clipAmount;
+        invalidate();
     }
 
     /**
@@ -847,6 +873,10 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
                 getWidth() - getPaddingEnd(),
                 getHeight() - getPaddingBottom()
         );
+
+        //also update clipping rect
+        clippedRect.set(contentRect);
+        setClipAmount(clipAmount);
     }
 
     /**
@@ -890,6 +920,9 @@ public class SparkView extends View implements ScrubGestureDetector.ScrubListene
         }
 
         setScrubLine(x);
+        if(clipOnScrub) {
+            setClipAmount(x / contentRect.right);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is something we needed for our project, if you want to add it to the original codebase here it is!  
The change allows to clip the spark-line horizontally and draws a grey line under it. 
The gif sums it up pretty well.

`public void setClipAmount(float amount)` to set a value between 0 and 1. If value is 1 clipping gets automatically disabled. (Passed value get clipped between 0 and 1)
There's also a ` public boolean clipOnScrub` to automatically use it when scrubbing.

![clip](https://user-images.githubusercontent.com/19847464/37130476-d9c71140-2283-11e8-8644-9b42024fe088.gif)
