### PR TITLE
Implement fading sides

### DIFF
--- a/spark/src/main/res/values/attrs.xml
+++ b/spark/src/main/res/values/attrs.xml
@@ -25,6 +25,8 @@
 
         <attr name="spark_scrubEnabled" format="boolean|reference" />
 
+        <attr name="spark_fadeLength" format="float|reference" />
+
         <attr name="spark_animateChanges" format="boolean|reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This one is a bit specific. It allows to add a straight segment that fades out at the beginning and at the end of the graph.
The amount is customizable and can be set directly in the xml. `fadeLength`
![fade out sides](https://user-images.githubusercontent.com/19847464/37245545-efe41ae6-2499-11e8-81b2-969a950e62fb.png)

The fading segments possibly do not respect padding, but it's an easy fix.