### PR TITLE
Modernize build dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
     - platform-tools
     - tools
     - android-26
-    - build-tools-26.0.2
+    - build-tools-26.0.3
     - extra-android-m2repository
 
 script:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/spark-sample/build.gradle
+++ b/spark-sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         applicationId "com.robinhood.spark.sample"

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -13,9 +13,10 @@ android {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.13.0'
     implementation 'com.android.support:support-annotations:26.1.0'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.18.0'
 }
 
 apply from: 'gradle-mvn-push.gradle'


### PR DESCRIPTION
Didn't update to support 27.1.0 since that introduces a breaking change for `@IntDef`. 

I'm thinking if we want to go to 27 lets do that as part of Spark 2 since it'll transitively force consumers to update. 